### PR TITLE
Update logic in generate DB GitHub Action

### DIFF
--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -69,7 +69,7 @@ jobs:
         release_tag=${{ github.event.release.tag_name }}
         echo "Release tag: $release_tag"
 
-        # Remove existing tag in local and remove
+        # Remove existing tag in local and remote
         git tag -d $release_tag
         git push origin :refs/tags/$release_tag
 


### PR DESCRIPTION
This will now always update the repo with database file(s) if it is run. The moving of the tag will only happen if this is a published release.