### PR TITLE
Switch GitHub Actions workflows from pip to uv

### DIFF
--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -16,15 +16,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v5
       with:
         python-version: '3.13'
-    
+        enable-cache: true
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install astrodb_utils
+      run: uv pip install --system astrodb_utils
 
     - name: Generate sqlite (file) database
       run: |

--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -64,10 +64,10 @@ jobs:
           # Try to get branch from git (works if we're on a branch)
           branch_name=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
           # If detached HEAD, try ref_name (might be a branch or tag)
-          if [ -z "$BRANCH" ]; then
+          if [ -z "$branch_name" ]; then
             branch_name="${{ github.ref_name }}"
             # If ref_name looks like a tag (contains dots or starts with v), use main
-            if [[ "$BRANCH" =~ \. ]] || [[ "$BRANCH" =~ ^v ]]; then
+            if [[ "$branch_name" =~ \. ]] || [[ "$branch_name" =~ ^v ]]; then
               branch_name="main"
             fi
           fi

--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -23,7 +23,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv venv
         uv pip install astrodb_utils
 
     - name: Generate sqlite (file) database

--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -22,12 +22,14 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies
-      run: uv pip install --system astrodb_utils
+      run: |
+        uv venv
+        uv pip install astrodb_utils
 
     - name: Generate sqlite (file) database
       run: |
         # Generate database
-        build_db_from_json database.toml
+        uv run build_db_from_json database.toml
       working-directory: .
       shell: bash
 

--- a/.github/workflows/make_erd.yml
+++ b/.github/workflows/make_erd.yml
@@ -28,7 +28,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install graphviz libgraphviz-dev
-        uv venv
         uv pip install astrodbkit eralchemy2 lsst-felis
 
     - name: Run script

--- a/.github/workflows/make_erd.yml
+++ b/.github/workflows/make_erd.yml
@@ -20,16 +20,15 @@ jobs:
       with:
         token: ${{ secrets.GH_TOKEN }}
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v3
+    - uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.13"
+        enable-cache: true
 
     - name: Install dependencies
       run: |
         sudo apt install graphviz libgraphviz-dev
-        python -m pip install --upgrade pip
-        pip install astrodbkit eralchemy2 lsst-felis
+        uv pip install --system astrodbkit eralchemy2 lsst-felis
 
     - name: Run script
       run: |

--- a/.github/workflows/make_erd.yml
+++ b/.github/workflows/make_erd.yml
@@ -28,11 +28,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install graphviz libgraphviz-dev
-        uv pip install --system astrodbkit eralchemy2 lsst-felis
+        uv venv
+        uv pip install astrodbkit eralchemy2 lsst-felis
 
     - name: Run script
       run: |
-        python scripts/make_schema_erd.py
+        uv run python scripts/make_schema_erd.py
 
     - name: Commit diagram
       run: |

--- a/.github/workflows/run_astrodb_utils.yml
+++ b/.github/workflows/run_astrodb_utils.yml
@@ -42,7 +42,6 @@ jobs:
 
     - name: Install astrodb_utils and dependencies needed for running tests
       run: |
-        uv venv
         uv pip install .[test]
 
     - name: Confirm branches

--- a/.github/workflows/run_astrodb_utils.yml
+++ b/.github/workflows/run_astrodb_utils.yml
@@ -25,25 +25,25 @@ jobs:
 
     steps:
     - name: Checkout utils repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v4
       with:
         repository: astrodbtoolkit/astrodb_utils
         ref: ${{ inputs.scripts_branch }}
 
     - name: Checkout template database repo to subdirectory
-      uses: actions/checkout@v5
+      uses: actions/checkout@v4
       with:
         path: tests/astrodb-template-db
 
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.13"
+        enable-cache: true
 
     - name: Install astrodb_utils and dependencies needed for running tests
       run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
+        uv venv
+        uv pip install .[test]
 
     - name: Confirm branches
       run: |
@@ -59,4 +59,4 @@ jobs:
 
     - name: Test astrodb_utils with current branch of template
       run: |
-        pytest
+        uv run pytest

--- a/.github/workflows/run_scheduled_tests.yml
+++ b/.github/workflows/run_scheduled_tests.yml
@@ -31,4 +31,4 @@ jobs:
         uv pip install astrodbkit lsst-felis pytest pytest-cov astrodb-utils
     - name: Test with pytest
       run: |
-        uv run pytest --cov=schema -s -rpP tests/scheduled_checks.py
+        uv run pytest -s -rpP tests/scheduled_checks.py

--- a/.github/workflows/run_scheduled_tests.yml
+++ b/.github/workflows/run_scheduled_tests.yml
@@ -27,7 +27,6 @@ jobs:
         enable-cache: true
     - name: Install dependencies
       run: |
-        uv venv
         uv pip install astrodbkit lsst-felis pytest pytest-cov astrodb-utils
     - name: Test with pytest
       run: |

--- a/.github/workflows/run_scheduled_tests.yml
+++ b/.github/workflows/run_scheduled_tests.yml
@@ -21,17 +21,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
+        enable-cache: true
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install astrodbkit
-        pip install lsst-felis
-        pip install pytest pytest-cov
-        pip install astrodb-utils
+      run: uv pip install --system astrodbkit lsst-felis pytest pytest-cov astrodb-utils
     - name: Test with pytest
       run: |
         pytest --cov=schema -s -rpP tests/scheduled_checks.py

--- a/.github/workflows/run_scheduled_tests.yml
+++ b/.github/workflows/run_scheduled_tests.yml
@@ -26,7 +26,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
     - name: Install dependencies
-      run: uv pip install --system astrodbkit lsst-felis pytest pytest-cov astrodb-utils
+      run: |
+        uv venv
+        uv pip install astrodbkit lsst-felis pytest pytest-cov astrodb-utils
     - name: Test with pytest
       run: |
-        pytest --cov=schema -s -rpP tests/scheduled_checks.py
+        uv run pytest --cov=schema -s -rpP tests/scheduled_checks.py

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,8 +28,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
     - name: Install dependencies
-      run: uv pip install --system astrodbkit astrodb-utils lsst-felis pytest pytest-cov
+      run: |
+        uv venv
+        uv pip install astrodbkit astrodb-utils lsst-felis pytest pytest-cov
 
     - name: Test with pytest
       run: |
-        pytest -p no:warnings --cov=schema tests
+        uv run pytest -p no:warnings --cov=schema tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -29,7 +29,6 @@ jobs:
         enable-cache: true
     - name: Install dependencies
       run: |
-        uv venv
         uv pip install astrodbkit astrodb-utils lsst-felis pytest pytest-cov
 
     - name: Test with pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,4 +34,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        uv run pytest -p no:warnings --cov=schema tests
+        uv run pytest -p no:warnings tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,17 +23,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ matrix.python-version }}
+        enable-cache: true
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install astrodbkit
-        pip install astrodb-utils
-        pip install lsst-felis
-        pip install pytest pytest-cov
+      run: uv pip install --system astrodbkit astrodb-utils lsst-felis pytest pytest-cov
 
     - name: Test with pytest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,15 @@
 # Ignore the database file and misc
 *.db
 *.pyc
+__pycache__/
 .idea
 .vscode
 .pytest_cache
-.ds_store
+.DS_Store
 .coverage
 .env
 .cursor
 CLAUDE.md
 
 # Database files
-*.db
 tests/*.sqlite

--- a/tests/scheduled_checks.py
+++ b/tests/scheduled_checks.py
@@ -77,7 +77,7 @@ def test_spectra_urls(db):
     codes = []
     internet, _ = internet_connection()
     if internet:
-        for spectrum_url in tqdm(spectra_urls["access_url"]):
+        for spectrum_url in tqdm.tqdm(spectra_urls["access_url"]):
             request_response = requests.head(spectrum_url)
             status_code = request_response.status_code
             # The website is up if the status code is 200
@@ -89,4 +89,4 @@ def test_spectra_urls(db):
     # Display broken spectra regardless if it's the number we expect or not
     print(f"found {len(broken_urls)} broken spectra urls: {broken_urls}, {codes}")
 
-    assert len(broken_urls) == 4
+    assert len(broken_urls) == 0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -101,3 +101,15 @@ def test_adding_data(db):
         db.query(db.Photometry).filter(db.Photometry.c.source == "V4046 Sgr").count()
         == 1
     )
+
+    # Clean up — remove in reverse FK order so constraints aren't violated
+    with db.session as session:
+        session.delete(phot)
+        session.commit()
+    with db.session as session:
+        session.delete(s)
+        session.delete(ref)
+        session.delete(tel)
+        session.delete(pf)
+        session.delete(reg)
+        session.commit()

--- a/tests/test_felis.py
+++ b/tests/test_felis.py
@@ -14,4 +14,4 @@ def test_schema():
     try:
         schema = Schema.model_validate(data)  # noqa: F841
     except ValidationError as e:
-        print(e)
+        raise AssertionError(f"Schema failed Felis validation:\n{e}") from e


### PR DESCRIPTION
Claude identified small problems that were easy to fix.

### GitHub Actions — migrate to `uv`

- All workflows now use `astral-sh/setup-uv` instead of `actions/setup-python`
- Replaced `pip install` with `uv venv` + `uv pip install` in all workflows
- Replaced bare `pytest` calls with `uv run pytest`
- Standardized `actions/checkout` to `@v4` across all workflows
- Fixed a shell variable bug in `generate_db.yml`: `$BRANCH` was never set; references corrected to `$branch_name`, so the tag-detection logic that prevents pushing to a tag ref now works correctly
- Removed bogus `--cov=schema` from pytest commands (there is no Python package named `schema` to measure coverage of)

### Tests — correctness fixes

- `test_felis.py`: schema validation errors now actually fail the test (previously the `except` block printed the error and silently passed)
- `test_database.py`: `test_adding_data` now cleans up all inserted rows at the end, preventing state from leaking into other tests
- `scheduled_checks.py`: fixed `tqdm(...)` → `tqdm.tqdm(...)` (would have raised `TypeError` if the test were ever unskipped); corrected `broken_urls` assertion from `== 4` to `== 0` (the template database has no spectra)

### `.gitignore`

- Removed duplicate `*.db` entry
- Added `__pycache__/`
- Fixed `.ds_store` → `.DS_Store` (correct casing for macOS)
