### PR TITLE
Update GitHub Actions to latest versions (#212)

### DIFF
--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@v7
+
+    - uses: astral-sh/setup-uv@v9.0.0
       with:
         python-version: '3.13'
         enable-cache: true
+        activate-environment: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/make_erd.yml
+++ b/.github/workflows/make_erd.yml
@@ -16,14 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         token: ${{ secrets.GH_TOKEN }}
 
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v9.0.0
       with:
         python-version: "3.13"
         enable-cache: true
+        activate-environment: true
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/run_astrodb_utils.yml
+++ b/.github/workflows/run_astrodb_utils.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/run_astrodb_utils.yml
+++ b/.github/workflows/run_astrodb_utils.yml
@@ -25,20 +25,21 @@ jobs:
 
     steps:
     - name: Checkout utils repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: astrodbtoolkit/astrodb_utils
         ref: ${{ inputs.scripts_branch }}
 
     - name: Checkout template database repo to subdirectory
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         path: tests/astrodb-template-db
 
-    - uses: astral-sh/setup-uv@v5
+    - uses: astral-sh/setup-uv@v9.0.0
       with:
         python-version: "3.13"
         enable-cache: true
+        activate-environment: true
 
     - name: Install astrodb_utils and dependencies needed for running tests
       run: |

--- a/.github/workflows/run_scheduled_tests.yml
+++ b/.github/workflows/run_scheduled_tests.yml
@@ -20,11 +20,12 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@v7
+    - uses: astral-sh/setup-uv@v9.0.0
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
+        activate-environment: true
     - name: Install dependencies
       run: |
         uv pip install astrodbkit lsst-felis pytest pytest-cov astrodb-utils

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,11 +22,12 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@v7
+    - uses: astral-sh/setup-uv@v9.0.0
       with:
         python-version: ${{ matrix.python-version }}
         enable-cache: true
+        activate-environment: true
     - name: Install dependencies
       run: |
         uv pip install astrodbkit astrodb-utils lsst-felis pytest pytest-cov


### PR DESCRIPTION
Bump actions/checkout v4->v7 and astral-sh/setup-uv v5->v9.0.0. Add activate-environment: true, required since setup-uv v6 no longer auto-activates a venv from python-version.